### PR TITLE
Recommendations

### DIFF
--- a/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceBroadcastReceiver.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceBroadcastReceiver.kt
@@ -21,7 +21,6 @@ class GeofenceBroadcastReceiver() : BroadcastReceiver() {
         RestAPI()
     private lateinit var poiSerialized: String
     private lateinit var poiObject: POI
-    private val geoCon = GeofencingController()
 
     override fun onReceive(context: Context?, intent: Intent?) {
         val geofencingEvent = GeofencingEvent.fromIntent(intent)

--- a/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
@@ -146,23 +146,19 @@ class GeofenceTriggeredActivity : AppCompatActivity() {
         favorite_button.setOnClickListener { toggleFavoritePOI(POI) }
         Log.v(TRIG_TAG, POI.toString())
 
-        // Demo on how to update category score
+        // User-feedback for recommendation
         catViewModel = ViewModelProvider(this).get(CategoryViewModel::class.java)
-        // We don't need to check if the category is in the database - DataController checks
-        // and adds all those which are not in the database.
-        catViewModel.updateCategoryPoints(POI.id, 1.0)
-
         like.setOnClickListener {
-            catViewModel.updateCategoryPoints(POI.id, 1.0)
+            catViewModel.like(POI.categoryID)
             like.isEnabled = false
             dislike.isEnabled = false
-        } // Increment score by +1 for a total of +2
+        }
 
-        like.setOnClickListener {
-            catViewModel.updateCategoryPoints(POI.id, -2.0)
+        dislike.setOnClickListener {
+            catViewModel.dislike(POI.categoryID)
             like.isEnabled = false
             dislike.isEnabled = false
-        } // Decrement score by -2
+        }
         // TODO table doesn't seem to update
     }
 

--- a/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
@@ -148,7 +148,22 @@ class GeofenceTriggeredActivity : AppCompatActivity() {
 
         // Demo on how to update category score
         catViewModel = ViewModelProvider(this).get(CategoryViewModel::class.java)
-        catViewModel.updateCategoryPoints(POI.categoryID, 2.0) // Change score
+        // We don't need to check if the category is in the database - DataController checks
+        // and adds all those which are not in the database.
+        catViewModel.updateCategoryPoints(POI.id, 1.0)
+
+        like.setOnClickListener {
+            catViewModel.updateCategoryPoints(POI.id, 1.0)
+            like.isEnabled = false
+            dislike.isEnabled = false
+        } // Increment score by +1 for a total of +2
+
+        like.setOnClickListener {
+            catViewModel.updateCategoryPoints(POI.id, -2.0)
+            like.isEnabled = false
+            dislike.isEnabled = false
+        } // Decrement score by -2
+        // TODO table doesn't seem to update
     }
 
     private fun toggleFavoritePOI(poi: POI) {

--- a/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
@@ -148,7 +148,7 @@ class GeofenceTriggeredActivity : AppCompatActivity() {
 
         // Demo on how to update category score
         catViewModel = ViewModelProvider(this).get(CategoryViewModel::class.java)
-        catViewModel.updateCategoryPoints("School", 2.0) // Change score
+        catViewModel.updateCategoryPoints(POI.categoryID, 2.0) // Change score
     }
 
     private fun toggleFavoritePOI(poi: POI) {

--- a/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/GeofenceTriggeredActivity.kt
@@ -1,5 +1,6 @@
 package com.teampower.cicerone
 
+import android.os.Build
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
@@ -7,6 +8,7 @@ import android.text.Html
 import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
@@ -20,7 +22,7 @@ import kotlinx.android.synthetic.main.activity_scrolling.toolbar
 import kotlinx.android.synthetic.main.content_geofence_triggered.*
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import org.threeten.bp.Instant
+import java.time.Instant
 import java.util.*
 
 
@@ -34,6 +36,7 @@ class GeofenceTriggeredActivity : AppCompatActivity() {
     private var tts_text = ""
     private var isSaved = false
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_geofence_triggered)
@@ -148,20 +151,21 @@ class GeofenceTriggeredActivity : AppCompatActivity() {
 
         // User-feedback for recommendation
         catViewModel = ViewModelProvider(this).get(CategoryViewModel::class.java)
-        like.setOnClickListener {
+        like_button.setOnClickListener {
             catViewModel.like(POI.categoryID)
-            like.isEnabled = false
-            dislike.isEnabled = false
+            like_button.isEnabled = false
+            dislike_button.isEnabled = false
         }
 
-        dislike.setOnClickListener {
+        dislike_button.setOnClickListener {
             catViewModel.dislike(POI.categoryID)
-            like.isEnabled = false
-            dislike.isEnabled = false
+            like_button.isEnabled = false
+            dislike_button.isEnabled = false
         }
         // TODO table doesn't seem to update
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun toggleFavoritePOI(poi: POI) {
         MainScope().launch {
             val result = poiSavedViewModel.loadPOI(poi.id).await()

--- a/cicerone/app/src/main/java/com/teampower/cicerone/MainActivity.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/MainActivity.kt
@@ -90,12 +90,13 @@ class MainActivity : AppCompatActivity() {
             pois?.let { savedAdapter.setPOIs(it) }
         })
 
-        // Connect to local table of category scores
+        // Connect to local table of category scores - have to do this here since datacon is not a viewmodel provider
         catViewModel = ViewModelProvider(this).get(CategoryViewModel::class.java)
         catViewModel.allCat.observe(this, Observer { cats ->
             // Set table of scores in DataCon
             dataCon.setCategoryScores(cats)
         })
+        dataCon.setCatViewModel(catViewModel)
 
 
         // Setup location services

--- a/cicerone/app/src/main/java/com/teampower/cicerone/POI.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/POI.kt
@@ -21,6 +21,7 @@ data class POI(
     val distance: Int,
     val address: String,
     val category: String,
+    val categoryID: String,
     val description: String = "No description yet."
 ) {
 }

--- a/cicerone/app/src/main/java/com/teampower/cicerone/control/DataController.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/control/DataController.kt
@@ -114,8 +114,13 @@ class DataController(private val geoCon: GeofencingController) {
         val distance = venue.location.distance
         val address = venue.location.formattedAddress.joinToString()
         var categories = ""
+        var categoryID = ""
         for (cat in venue.categories) {
             categories = categories + cat.name
+            if(categoryID!= ""){
+                categoryID = categoryID + ","  // Add delimiter between Ids
+            }
+            categoryID = categoryID + cat.id
         }
         return POI(
             id.toString(),
@@ -124,7 +129,8 @@ class DataController(private val geoCon: GeofencingController) {
             long,
             distance,
             address,
-            categories
+            categories,
+            categoryID
         )
     }
 
@@ -134,6 +140,7 @@ class DataController(private val geoCon: GeofencingController) {
         poi_string.append("Location: ${poi.lat}, ${poi.long}").appendln()
         poi_string.append("Address: ${poi.address}").appendln()
         poi_string.append("Category: ${poi.category}").appendln()
+        poi_string.append("CategoryIDs: ${poi.categoryID}").appendln()
         poi_string.append("Current distance: ${poi.distance}m")
         venue_view.text = poi_string
     }
@@ -171,16 +178,19 @@ class DataController(private val geoCon: GeofencingController) {
         val indicesNotToAdd = ArrayList<Int>()
         for (i in venues.indices) {
             for (j in i + 1 until venues.size) {
+                val venueA = venues[i]
+                val venueB = venues[j]
+
                 val locationA = Location("A")
-                locationA.latitude = venues[i].location.lat
-                locationA.longitude = venues[i].location.lng
+                locationA.latitude = venueA.location.lat
+                locationA.longitude = venueA.location.lng
                 val locationB = Location("B")
-                locationB.latitude = venues[j].location.lat
-                locationB.longitude = venues[j].location.lng
+                locationB.latitude = venueB.location.lat
+                locationB.longitude = venueB.location.lng
 
                 val distanceAB = locationA.distanceTo(locationB) // Distance between AB
-                val distanceAUser = venues[i].location.distance // Distance between A and user
-                val distanceBUser = venues[j].location.distance // Distance between B and user
+                val distanceAUser = venueA.location.distance // Distance between A and user
+                val distanceBUser = venueB.location.distance // Distance between B and user
                 // Filter out the POI that's farthest away
                 if( distanceAB < threshold ) {
                     // If overlapping, make sure not to add the farthest POI
@@ -189,6 +199,9 @@ class DataController(private val geoCon: GeofencingController) {
                     } else{
                         indicesNotToAdd.add(i)
                     }
+                    // TODO: In progress, new filtering based on CategoryScore
+                    Log.i(DATA_CON, venueA.categories.toString())
+                    Log.i(DATA_CON, venueB.categories.toString())
 
                 }
             }

--- a/cicerone/app/src/main/java/com/teampower/cicerone/control/DataController.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/control/DataController.kt
@@ -258,7 +258,7 @@ class DataController(private val geoCon: GeofencingController) {
                 var existInDB = false
                 for(dBCat in categoryTable){
                     // This will be true if cat matches once in the database, which is what we want to check
-                    Log.i(DATA_CON, "\tcat.id==dBcat.foursquareID: ${cat.id}===${dBCat.foursquareID} = ${dBCat.foursquareID == cat.id}")
+                    //Log.i(DATA_CON, "\tcat.id==dBcat.foursquareID: ${cat.id}===${dBCat.foursquareID} = ${dBCat.foursquareID == cat.id}")
                     existInDB = existInDB || dBCat.foursquareID == cat.id
                 }
                 if(!existInDB){

--- a/cicerone/app/src/main/java/com/teampower/cicerone/control/DataController.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/control/DataController.kt
@@ -156,9 +156,9 @@ class DataController(private val geoCon: GeofencingController) {
     private fun getClosestVenues(venues: List<Venues>): List<Venues> {
         val closestVenues = venues.sortedBy { venue -> venue.location.distance }
         if (closestVenues.size > 100 ){
-            return closestVenues.slice(0..5)
+            return closestVenues.slice(0..2)
         }
-        return closestVenues
+        return closestVenues.slice(0..2)
     }
 
     private fun calculateRadius(venues: List<Venues>): Float {
@@ -235,8 +235,9 @@ class DataController(private val geoCon: GeofencingController) {
                 }
             }
         }
-        if(score==0.0){
+        if(score<1){
             // If category is not in databse, add that category to the database and initialize the score to 1
+            // Or if decremented below pseudocount, increase to 1. Works due to replace strategy on insert.
             for(cat in categories){
                 categoryViewModel.insert(CategoryData(cat.id, cat.name, 1.0))
                 Log.i(DATA_CON, "Category ${cat.name} added to database")

--- a/cicerone/app/src/main/java/com/teampower/cicerone/database/CategoryDao.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/database/CategoryDao.kt
@@ -14,11 +14,11 @@ interface CategoryDao {
     @Query("SELECT * FROM category_table")
     fun getAll(): LiveData<List<CategoryData>>
 
-    @Query("UPDATE category_table SET score = score + (:points) WHERE foursquareID = (:foursquareID)")
-    fun updateCategoryPoints(foursquareID: String, points: Double): Int
+    @Query("UPDATE category_table SET likes = likes + 1 WHERE foursquareID = (:foursquareID)")
+    fun like(foursquareID: String): Int
 
-    @Query("SELECT * FROM category_table WHERE foursquareID = (:foursquareID)")
-    fun getCategoryPoints(foursquareID: String): Double
+    @Query("UPDATE category_table SET dislikes = dislikes + 1 WHERE foursquareID = (:foursquareID)")
+    fun dislike(foursquareID: String): Int
 
     @Query("DELETE FROM category_table")
     suspend fun deleteAll()

--- a/cicerone/app/src/main/java/com/teampower/cicerone/database/CategoryDao.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/database/CategoryDao.kt
@@ -14,11 +14,11 @@ interface CategoryDao {
     @Query("SELECT * FROM category_table")
     fun getAll(): LiveData<List<CategoryData>>
 
-    @Query("UPDATE category_table SET score = score + (:points) WHERE name = (:catName)")
-    fun updateCategoryPoints(catName: String, points: Double): Int
+    @Query("UPDATE category_table SET score = score + (:points) WHERE foursquareID = (:foursquareID)")
+    fun updateCategoryPoints(foursquareID: String, points: Double): Int
 
-    @Query("SELECT * FROM category_table WHERE name = (:catName)")
-    fun getCategoryPoints(catName: String): Double
+    @Query("SELECT * FROM category_table WHERE foursquareID = (:foursquareID)")
+    fun getCategoryPoints(foursquareID: String): Double
 
     @Query("DELETE FROM category_table")
     suspend fun deleteAll()

--- a/cicerone/app/src/main/java/com/teampower/cicerone/database/CiceroneAppDatabase.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/database/CiceroneAppDatabase.kt
@@ -46,12 +46,12 @@ public abstract class CiceroneAppDatabase : RoomDatabase() {
                     //************* Category table *************
                     val catDao = database.categoryDao()
                     // Delete all content here.
-                    catDao.deleteAll() // Only when resetting
+                    // catDao.deleteAll() // Only when resetting
                     // Initialize table
-                    val cat1 = CategoryData("52e81612bcbc57f1066b7a14", "Palace", 1.0)
-                    catDao.insert(cat1)
-                    val cat2 = CategoryData("50aaa49e4b90af0d42d5de11", "Castle", 1.0)
-                    catDao.insert(cat2)
+                    //val cat1 = CategoryData("52e81612bcbc57f1066b7a14", "Palace", 1, 1)
+                    //catDao.insert(cat1)
+                    //val cat2 = CategoryData("50aaa49e4b90af0d42d5de11", "Castle", 1, 1)
+                    //catDao.insert(cat2)
                 }
             }
         }

--- a/cicerone/app/src/main/java/com/teampower/cicerone/database/CiceroneAppDatabase.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/database/CiceroneAppDatabase.kt
@@ -48,8 +48,10 @@ public abstract class CiceroneAppDatabase : RoomDatabase() {
                     // Delete all content here.
                     catDao.deleteAll() // Only when resetting
                     // Initialize table
-                    val cat = CategoryData("School", 1.0)
-                    catDao.insert(cat)
+                    val cat1 = CategoryData("52e81612bcbc57f1066b7a14", "Palace", 1.0)
+                    catDao.insert(cat1)
+                    val cat2 = CategoryData("50aaa49e4b90af0d42d5de11", "Castle", 1.0)
+                    catDao.insert(cat2)
                 }
             }
         }

--- a/cicerone/app/src/main/java/com/teampower/cicerone/database/Entities.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/database/Entities.kt
@@ -26,6 +26,7 @@ data class POISavedData(
 
 @Entity(tableName = "category_table")
 data class CategoryData(
-    @PrimaryKey val name: String,
+    @PrimaryKey val foursquareID: String,
+    @ColumnInfo val name: String,
     @ColumnInfo val score: Double
 )

--- a/cicerone/app/src/main/java/com/teampower/cicerone/database/Entities.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/database/Entities.kt
@@ -28,5 +28,6 @@ data class POISavedData(
 data class CategoryData(
     @PrimaryKey val foursquareID: String,
     @ColumnInfo val name: String,
-    @ColumnInfo val score: Double
+    @ColumnInfo val likes: Int,
+    @ColumnInfo val dislikes: Int
 )

--- a/cicerone/app/src/main/java/com/teampower/cicerone/database/repositories/CategoryRepository.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/database/repositories/CategoryRepository.kt
@@ -20,10 +20,10 @@ class CategoryRepository(private val catDao: CategoryDao) {
     suspend fun insert(cat: CategoryData) {
         catDao.insert(cat)
     }
-    fun updateCategoryPoints(catName: String, points: Double) {
-        catDao.updateCategoryPoints(catName, points)
+    fun like(catName: String) {
+        catDao.like(catName)
     }
-    fun getCategoryPoints(catName: String) {
-        catDao.getCategoryPoints(catName)
+    fun dislike(catName: String) {
+        catDao.dislike(catName)
     }
 }

--- a/cicerone/app/src/main/java/com/teampower/cicerone/viewmodels/CategoryViewModel.kt
+++ b/cicerone/app/src/main/java/com/teampower/cicerone/viewmodels/CategoryViewModel.kt
@@ -47,11 +47,11 @@ class CategoryViewModel(application: Application) : AndroidViewModel(application
         repository.insert(cat)
     }
 
-    fun updateCategoryPoints(catName: String, points: Double) = viewModelScope.launch(Dispatchers.IO) {
-        repository.updateCategoryPoints(catName, points)
+    fun like(catName: String) = viewModelScope.launch(Dispatchers.IO) {
+        repository.like(catName)
+    }
+    fun dislike(catName: String) = viewModelScope.launch(Dispatchers.IO) {
+        repository.dislike(catName)
     }
 
-    fun getCategoryPoints(catName: String) = viewModelScope.launch(Dispatchers.IO) {
-        repository.getCategoryPoints(catName)
-    }
 }

--- a/cicerone/app/src/main/res/layout/activity_geofence_triggered.xml
+++ b/cicerone/app/src/main/res/layout/activity_geofence_triggered.xml
@@ -31,11 +31,12 @@
                 app:popupTheme="@style/AppTheme.PopupOverlay" />
 
 
+
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical"
-                android:paddingLeft="10dp"
                 android:paddingTop="64dp">
 
                 <TextView
@@ -43,6 +44,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/location_type_height"
                     android:text="@string/location_category"
+                    android:paddingLeft="10dp"
                     android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                 <TextView
@@ -50,8 +52,34 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/location_type_height"
                     android:text="@string/location_distance"
+                    android:paddingLeft="10dp"
                     android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:orientation="horizontal">
+
+                    <Button
+                        android:id="@+id/like"
+                        android:layout_width="100dp"
+                        android:layout_height="wrap_content"
+                        android:backgroundTint="#009688"
+                        android:insetRight="10dp"
+                        android:text="Like" />
+
+                    <Button
+                        android:id="@+id/dislike"
+                        android:layout_width="100dp"
+                        android:layout_height="wrap_content"
+                        android:backgroundTint="#009688"
+                        android:insetLeft="10dp"
+                        android:text="Dislike" />
+                </LinearLayout>
+
             </LinearLayout>
+
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>

--- a/cicerone/app/src/main/res/layout/activity_geofence_triggered.xml
+++ b/cicerone/app/src/main/res/layout/activity_geofence_triggered.xml
@@ -54,30 +54,6 @@
                     android:text="@string/location_distance"
                     android:paddingLeft="10dp"
                     android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:orientation="horizontal">
-
-                    <Button
-                        android:id="@+id/like"
-                        android:layout_width="100dp"
-                        android:layout_height="wrap_content"
-                        android:backgroundTint="#009688"
-                        android:insetRight="10dp"
-                        android:text="Like" />
-
-                    <Button
-                        android:id="@+id/dislike"
-                        android:layout_width="100dp"
-                        android:layout_height="wrap_content"
-                        android:backgroundTint="#009688"
-                        android:insetLeft="10dp"
-                        android:text="Dislike" />
-                </LinearLayout>
-
             </LinearLayout>
 
 

--- a/cicerone/app/src/main/res/layout/content_geofence_triggered.xml
+++ b/cicerone/app/src/main/res/layout/content_geofence_triggered.xml
@@ -60,31 +60,36 @@
 
     <TextView
         android:id="@+id/vote_label"
-        android:layout_width="200dp"
+        android:layout_width="250dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="48dp"
+        android:layout_marginTop="64dp"
         android:text="@string/vote_button_label"
         app:layout_constraintStart_toStartOf="@+id/tts_label"
-        app:layout_constraintTop_toTopOf="@+id/wikipedia_link_url" />
+        app:layout_constraintTop_toTopOf="@+id/tts_button" />
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="@+id/vote_label"
         app:layout_constraintTop_toBottomOf="@+id/vote_label"
         android:orientation="horizontal">
 
-        <ImageButton
+        <Button
             android:id="@+id/like_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:srcCompat="@drawable/ic_play_arrow_black_32dp" />
+            android:backgroundTint="#009688"
+            android:contentDescription="Like button"
+            android:text="Like" />
 
-        <ImageButton
+        <Button
             android:id="@+id/dislike_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:srcCompat="@drawable/ic_play_arrow_black_32dp" />
+            android:background="#FFFFFF"
+            android:backgroundTint="#009688"
+            android:contentDescription="Dislike button"
+            android:text="Dislike" />
     </LinearLayout>
 
     <androidx.constraintlayout.widget.Guideline

--- a/cicerone/app/src/main/res/layout/content_geofence_triggered.xml
+++ b/cicerone/app/src/main/res/layout/content_geofence_triggered.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
@@ -56,6 +57,35 @@
         app:layout_constraintStart_toStartOf="@+id/tts_label"
         app:layout_constraintTop_toBottomOf="@+id/tts_label"
         app:srcCompat="@drawable/ic_play_arrow_black_32dp" />
+
+    <TextView
+        android:id="@+id/vote_label"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:text="@string/vote_button_label"
+        app:layout_constraintStart_toStartOf="@+id/tts_label"
+        app:layout_constraintTop_toTopOf="@+id/wikipedia_link_url" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintStart_toStartOf="@+id/vote_label"
+        app:layout_constraintTop_toBottomOf="@+id/vote_label"
+        android:orientation="horizontal">
+
+        <ImageButton
+            android:id="@+id/like_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/ic_play_arrow_black_32dp" />
+
+        <ImageButton
+            android:id="@+id/dislike_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/ic_play_arrow_black_32dp" />
+    </LinearLayout>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline"

--- a/cicerone/app/src/main/res/values/strings.xml
+++ b/cicerone/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="tts_text_no_wikipedia">You are close to %1$s, a %2$s %3$d meters away.</string>
     <string name="location_description">\"%1$s\" \n from Wikipedia</string>
     <string name="tts_button_label">Listen to information</string>
+    <string name='vote_button_label'>Was this recommendation helpful?</string>
 
     <string name="hint_word">Word…</string>
     <string name="button_save">Save</string>


### PR DESCRIPTION
Implements a Bayesian recommendations algorithm. 

Recommend POIs based on the user's preference. Uses a Bayesian approach, with the following definitions:
E_i: The event that the POI belongs to category i
M_j: User likes POI j. Either the user likes it or they don't,

We seek P(M_j|E_i) = P(liked j | category i). This can be inferred as (Bayes inference formula):
P(Liked|Category) = P(Category|Liked) * P(Liked) / (P(Category|Liked) * P(Liked) + P(Category|Disliked) * P(Disliked))

The likelihood P(Category|Liked) is computed from the fraction of likes for that category.
The prior P(liked) is set to flat 0.5 at the moment (may be tuned later).

Overlapping geofences are then handled by a greedy recursive algorithm, in which the POI with the highest score (likes-dislikes) is chosen over the other. In case of the same score, a random choice is made between the two. 

Problems with the current implementation:
- The prior P(liked) is set to flat 0.5 at the moment. Hence this has no effect as of now and our approach isn't really Bayesian (just likelihood estimate).
- Since almost all categories in the database has the same likes and dislikes (the initial values, likes=1 and dislikes=1), a random choice is almost always made. This can be solved by imposing other initialization values for popular palaces, e.g. initialize palaces to likes=10. A better solution in my opinion is to rather heavily restrict the list of categories from foursquare. Atm we have a lot of non-sensical categories like parking lots and jewellry stores getting recommended. If we limit ourselves to a curated subset of 10-20 interesting categories this may be overcome. 

Closes #39, closes #4